### PR TITLE
Fix namespacing for Shiny modules

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -25,13 +25,15 @@ print.bucket_list <- function(x, ...){
 # The names must be suffix values to allow for modules which use prefix values
 # https://github.com/rstudio/sortable/issues/100
 as_rank_list_id <- function(id) {
-  paste0("rank-list-", id)
+  # paste0("rank-list-", id)
+  paste0(id, "-rank-list")
 }
 # TODO: in future, change the order of paste, to enable shiny modules
 # paste0(id, "-rank-list")
 
 as_bucket_list_id <- function(id) {
-  paste0("bucket-list-", id)
+  # paste0("bucket-list-", id)
+  paste0(id, "-bucket-list")
 }
 # TODO: in future, change the order of paste, to enable shiny modules
 # paste0(id, "-bucket-list")

--- a/R/rank_list.R
+++ b/R/rank_list.R
@@ -164,9 +164,15 @@ update_rank_list <- function(css_id, text = NULL, labels = NULL,
   if ( !is.null(labels) && length(labels) > 0) {
     labels <- as.character(tagList(as_label_tags(labels)))
   }
-  message <- dropNulls(list(id = inputId, text = text, labels = labels))
-  session$sendInputMessage(inputId, message)
 
+  # include namespace in message 
+  # to conveniently correct the nested input IDs 
+  # of a rank-list widget inside rank_list_binding.js 
+  message <- dropNulls(list(id = inputId, 
+    text = text, 
+    labels = labels, 
+    namespace = session$ns("")))
+  session$sendInputMessage(inputId, message)
 }
 
 

--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
@@ -22,7 +22,7 @@ $.extend(ranklistBinding, {
     }
 
     if (data.labels) {
-      const short_id = data.id.replace(/^rank-list-/, "");
+      const short_id = data.namespace + data.id.replace(/-rank-list$/, "");
       $('#' + short_id).html(data.labels);
       const label_ids = $('#' + short_id).children().map((idx, child) => {
         return $(child).attr("data-rank-id") || $.trim(child.innerHTML);


### PR DESCRIPTION
### Summary

This PR fixes the namespacing issue described in **#100** where `update_rank_list()` fails inside Shiny modules because nested rank-list element IDs are not correctly namespaced.

### Background

Shiny namespacing applies only to top-level input IDs and does not automatically propagate to nested widget element IDs inside `inputMessages`. As a result, rank-list updates were being sent to non-namespaced DOM IDs, and the client-side binding could not locate the correct list container.

### What this PR changes

* `as_rank_list_id()` is updated to append the module namespace (`id`) instead of prepending it.
* The widget's JavaScript binding is updated so that `setValue()` correctly applies the namespace to inputIDs inside the message object. `update_rank_list()` explicitly stores the namespace of it's session into the message object, so that the shiny binding can apply it.

### Why this works

With this fix:

* Shiny's `session$ns()` becomes compatible with sortable’s internal ID patterns.
* `update_rank_list()` correctly updates the UI inside modules.
* No behavior changes occur for non-module contexts.

### Related Issue

Fixes **#100**