### PR TITLE
Fix rank_list bindings for modules

### DIFF
--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
@@ -16,18 +16,19 @@ $.extend(ranklistBinding, {
   getValue: function(el) { },
 
   setValue: function (el, data) {
-    // console.log(data);
     if (data.text) {
       $(el).find(".rank-list-title").text(data.text);
     }
 
     if (data.labels) {
-      const short_id = data.id.replace(/^rank-list-/, "");
-      $('#' + short_id).html(data.labels);
-      const label_ids = $('#' + short_id).children().map((idx, child) => {
+      // Get the input ID from the .rank-list child element (not the container)
+      const rankListEl = $(el).find(".rank-list");
+      const inputId = rankListEl.attr("id");
+      rankListEl.html(data.labels);
+      const label_ids = rankListEl.children().map((idx, child) => {
         return $(child).attr("data-rank-id") || $.trim(child.innerHTML);
       }).toArray();
-      Shiny.setInputValue(short_id, label_ids, {priority: 'event'});
+      Shiny.setInputValue(inputId, label_ids, {priority: 'event'});
     }
 
   },


### PR DESCRIPTION
Hi,

I noticed an issue where update_rank_list() did not work within the context of a shiny module, despite using the recent updates and calling enable_modules(). The Shiny JS binding for setValue was still looking for a prefix-based pattern to actually update the DOM. I believe this fix enables the function irrespective of the shiny context (module or not).

This might also address https://github.com/rstudio/sortable/issues/122